### PR TITLE
Update repository URL and bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.64.0"
 authors = ["Tobie Morgan Hitchcock <tobie@surrealdb.com>"]
 description = "SurrealDB official client"
-repository = "https://github.com/surrealdb/surrealdb/tree/main/client"
+repository = "https://github.com/surrealdb/surrealdb.rs"
 homepage = "https://surrealdb.com"
 documentation = "https://docs.rs/surrealdb-rs"
 readme = "README.md"
@@ -30,15 +30,15 @@ async-trait = "0.1.58"
 dmp = "0.1.1"
 flume = "0.10.14"
 futures = { version = "0.3.25", default-features = false, features = ["alloc", "executor"] }
-futures-concurrency = "6.0.1"
-indexmap = { version = "1.9.1", optional = true, features = ["serde"] }
+futures-concurrency = "7.0.0"
+indexmap = { version = "1.9.2", optional = true, features = ["serde"] }
 native-tls = { version = "0.2.11", optional = true }
 once_cell = "1.16.0"
-reqwest = { version = "0.11.12", default-features = false, features = ["json", "stream"], optional = true }
+reqwest = { version = "0.11.13", default-features = false, features = ["json", "stream"], optional = true }
 rustls = { version = "0.20.7", optional = true }
 semver = { version = "1.0.14", features = ["serde"] }
 serde = { version = "1.0.147", features = ["derive"] }
-serde_json = "1.0.87"
+serde_json = "1.0.88"
 serde_pack = { version = "1.1.1", package = "rmp-serde" }
 surrealdb = { git = "https://github.com/rushmorem/surrealdb", branch = "suppress-warnings", default-features = false }
 tokio-stream = { version = "0.1.11", optional = true }


### PR DESCRIPTION
## What is the motivation?

The repository URL is still pointing to `surrealdb/surrealdb` and some dependencies have newer releases.

## What does this change do?

Updates the repository URL to point to this repo and update dependencies to latest ones.

## What is your testing strategy?

I ran tests to make sure they all still pass.

## Is this related to any issues?

No