### PR TITLE
Require more types to be Sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,14 +64,21 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+          target: wasm32-unknown-unknown
           override: true
           components: rustfmt, clippy
 
-      - name: Run cargo check
+      - name: Run native cargo check
         uses: actions-rs/cargo@v1
         with:
           command: check
           args: --all-features
+
+      - name: Run Wasm cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --features http --target wasm32-unknown-unknown
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-async-trait = "0.1.58"
 dmp = "0.1.1"
 flume = "0.10.14"
 futures = { version = "0.3.25", default-features = false, features = ["alloc", "executor"] }

--- a/src/method/authenticate.rs
+++ b/src/method/authenticate.rs
@@ -4,8 +4,9 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
+use std::pin::Pin;
 
 /// An authentication future
 #[derive(Debug)]
@@ -19,7 +20,7 @@ where
     Client: Connection,
 {
     type Output = Result<()>;
-    type IntoFuture = BoxFuture<'r, Result<()>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/begin.rs
+++ b/src/method/begin.rs
@@ -3,9 +3,10 @@ use crate::method::Commit;
 use crate::Connection;
 use crate::Result;
 use crate::Surreal;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
 use std::ops::Deref;
+use std::pin::Pin;
 use surrealdb::sql::statements::BeginStatement;
 
 /// A beginning of a transaction
@@ -19,7 +20,7 @@ where
     C: Connection,
 {
     type Output = Result<Transaction<C>>;
-    type IntoFuture = BoxFuture<'static, Result<Transaction<C>>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'static>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/cancel.rs
+++ b/src/method/cancel.rs
@@ -1,8 +1,9 @@
 use crate::Connection;
 use crate::Result;
 use crate::Surreal;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
+use std::pin::Pin;
 use surrealdb::sql::statements::CancelStatement;
 
 /// A transaction cancellation future
@@ -16,7 +17,7 @@ where
     C: Connection,
 {
     type Output = Result<Surreal<C>>;
-    type IntoFuture = BoxFuture<'static, Result<Surreal<C>>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'static>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/commit.rs
+++ b/src/method/commit.rs
@@ -1,8 +1,9 @@
 use crate::Connection;
 use crate::Result;
 use crate::Surreal;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
+use std::pin::Pin;
 use surrealdb::sql::statements::CommitStatement;
 
 /// A transaction commit future
@@ -16,7 +17,7 @@ where
     C: Connection,
 {
     type Output = Result<Surreal<C>>;
-    type IntoFuture = BoxFuture<'static, Result<Surreal<C>>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'static>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/create.rs
+++ b/src/method/create.rs
@@ -5,11 +5,12 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
+use std::pin::Pin;
 
 /// A record create future
 #[derive(Debug)]
@@ -36,10 +37,10 @@ where
 impl<'r, Client, R> IntoFuture for Create<'r, Client, Option<R>>
 where
     Client: Connection,
-    R: DeserializeOwned + Send + 'r,
+    R: DeserializeOwned + Send + Sync + 'r,
 {
     type Output = Result<R>;
-    type IntoFuture = BoxFuture<'r, Result<R>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.execute())
@@ -49,10 +50,10 @@ where
 impl<'r, Client, R> IntoFuture for Create<'r, Client, Vec<R>>
 where
     Client: Connection,
-    R: DeserializeOwned + Send + 'r,
+    R: DeserializeOwned + Send + Sync + 'r,
 {
     type Output = Result<R>;
-    type IntoFuture = BoxFuture<'r, Result<R>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.execute())

--- a/src/method/delete.rs
+++ b/src/method/delete.rs
@@ -5,9 +5,10 @@ use crate::param::Range;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
+use std::pin::Pin;
 use surrealdb::sql::Id;
 
 /// A record delete future
@@ -39,7 +40,7 @@ where
     Client: Connection,
 {
     type Output = Result<()>;
-    type IntoFuture = BoxFuture<'r, Result<()>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.execute())
@@ -51,7 +52,7 @@ where
     Client: Connection,
 {
     type Output = Result<()>;
-    type IntoFuture = BoxFuture<'r, Result<()>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.execute())

--- a/src/method/export.rs
+++ b/src/method/export.rs
@@ -3,9 +3,10 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
 use std::path::PathBuf;
+use std::pin::Pin;
 
 /// A database export future
 #[derive(Debug)]
@@ -19,7 +20,7 @@ where
     Client: Connection,
 {
     type Output = Result<()>;
-    type IntoFuture = BoxFuture<'r, Result<()>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async {

--- a/src/method/health.rs
+++ b/src/method/health.rs
@@ -3,8 +3,9 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
+use std::pin::Pin;
 
 /// A health check future
 #[derive(Debug)]
@@ -17,7 +18,7 @@ where
     Client: Connection,
 {
     type Output = Result<()>;
-    type IntoFuture = BoxFuture<'r, Result<()>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async {

--- a/src/method/import.rs
+++ b/src/method/import.rs
@@ -3,9 +3,10 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
 use std::path::PathBuf;
+use std::pin::Pin;
 
 /// An database import future
 #[derive(Debug)]
@@ -19,7 +20,7 @@ where
     Client: Connection,
 {
     type Output = Result<()>;
-    type IntoFuture = BoxFuture<'r, Result<()>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async {

--- a/src/method/invalidate.rs
+++ b/src/method/invalidate.rs
@@ -3,8 +3,9 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
+use std::pin::Pin;
 
 /// A session invalidate future
 #[derive(Debug)]
@@ -17,7 +18,7 @@ where
     Client: Connection,
 {
     type Output = Result<()>;
-    type IntoFuture = BoxFuture<'r, Result<()>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async {

--- a/src/method/kill.rs
+++ b/src/method/kill.rs
@@ -3,8 +3,9 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
+use std::pin::Pin;
 use surrealdb::sql::Uuid;
 
 /// A live query kill future
@@ -19,7 +20,7 @@ where
     Client: Connection,
 {
     type Output = Result<()>;
-    type IntoFuture = BoxFuture<'r, Result<()>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/live.rs
+++ b/src/method/live.rs
@@ -3,8 +3,9 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
+use std::pin::Pin;
 use surrealdb::sql::Uuid;
 
 /// A live query future
@@ -19,7 +20,7 @@ where
     Client: Connection,
 {
     type Output = Result<Uuid>;
-    type IntoFuture = BoxFuture<'r, Result<Uuid>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/merge.rs
+++ b/src/method/merge.rs
@@ -6,12 +6,13 @@ use crate::param::Range;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::json;
+use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
+use std::pin::Pin;
 use surrealdb::sql::Id;
 
 /// A merge future
@@ -24,26 +25,38 @@ pub struct Merge<'r, C: Connection, D, R> {
     pub(super) response_type: PhantomData<R>,
 }
 
+impl<'r, C, D, R> Merge<'r, C, D, R>
+where
+    C: Connection,
+    D: Serialize,
+{
+    fn split(self) -> Result<(&'r Router<C>, Method, Param)> {
+        let resource = self.resource?;
+        let param = match self.range {
+            Some(range) => resource.with_range(range)?,
+            None => resource.into(),
+        };
+        let content = json!(self.content);
+        let param = Param::new(vec![param, from_json(content)]);
+        Ok((self.router?, Method::Merge, param))
+    }
+}
+
 impl<'r, Client, D, R> IntoFuture for Merge<'r, Client, D, R>
 where
     Client: Connection,
-    D: Serialize + Send + Sync + 'r,
-    R: DeserializeOwned + Send,
+    D: Serialize,
+    R: DeserializeOwned + Send + Sync,
 {
     type Output = Result<R>;
-    type IntoFuture = BoxFuture<'r, Result<R>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
+        let result = self.split();
         Box::pin(async move {
-            let resource = self.resource?;
-            let param = match self.range {
-                Some(range) => resource.with_range(range)?,
-                None => resource.into(),
-            };
-            let content = json!(self.content);
-            let mut conn = Client::new(Method::Merge);
-            conn.execute(self.router?, Param::new(vec![param, from_json(content)]))
-                .await
+            let (router, method, param) = result?;
+            let mut conn = Client::new(method);
+            conn.execute(router, param).await
         })
     }
 }

--- a/src/method/patch.rs
+++ b/src/method/patch.rs
@@ -6,10 +6,11 @@ use crate::param::Range;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
 use serde::de::DeserializeOwned;
+use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
+use std::pin::Pin;
 use surrealdb::sql::Array;
 use surrealdb::sql::Id;
 use surrealdb::sql::Value;
@@ -38,10 +39,10 @@ where
 impl<'r, Client, R> IntoFuture for Patch<'r, Client, R>
 where
     Client: Connection,
-    R: DeserializeOwned + Send,
+    R: DeserializeOwned + Send + Sync,
 {
     type Output = Result<R>;
-    type IntoFuture = BoxFuture<'r, Result<R>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/select.rs
+++ b/src/method/select.rs
@@ -5,10 +5,11 @@ use crate::param::Range;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
 use serde::de::DeserializeOwned;
+use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
+use std::pin::Pin;
 use surrealdb::sql::Id;
 
 /// A select future
@@ -41,10 +42,10 @@ where
 impl<'r, Client, R> IntoFuture for Select<'r, Client, Option<R>>
 where
     Client: Connection,
-    R: DeserializeOwned + Send + 'r,
+    R: DeserializeOwned + Send + Sync + 'r,
 {
     type Output = Result<R>;
-    type IntoFuture = BoxFuture<'r, Result<R>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.execute())
@@ -54,10 +55,10 @@ where
 impl<'r, Client, R> IntoFuture for Select<'r, Client, Vec<R>>
 where
     Client: Connection,
-    R: DeserializeOwned + Send + 'r,
+    R: DeserializeOwned + Send + Sync + 'r,
 {
     type Output = Result<Vec<R>>;
-    type IntoFuture = BoxFuture<'r, Result<Vec<R>>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(self.execute())

--- a/src/method/set.rs
+++ b/src/method/set.rs
@@ -3,8 +3,9 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
+use std::pin::Pin;
 use surrealdb::sql::Value;
 
 /// A set future
@@ -20,7 +21,7 @@ where
     Client: Connection,
 {
     type Output = Result<()>;
-    type IntoFuture = BoxFuture<'r, Result<()>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/signin.rs
+++ b/src/method/signin.rs
@@ -3,10 +3,11 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
 use serde::de::DeserializeOwned;
+use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
+use std::pin::Pin;
 use surrealdb::sql::Value;
 
 /// A signin future
@@ -20,10 +21,10 @@ pub struct Signin<'r, C: Connection, R> {
 impl<'r, Client, R> IntoFuture for Signin<'r, Client, R>
 where
     Client: Connection,
-    R: DeserializeOwned + Send,
+    R: DeserializeOwned + Send + Sync,
 {
     type Output = Result<R>;
-    type IntoFuture = BoxFuture<'r, Result<R>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/signup.rs
+++ b/src/method/signup.rs
@@ -3,10 +3,11 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
 use serde::de::DeserializeOwned;
+use std::future::Future;
 use std::future::IntoFuture;
 use std::marker::PhantomData;
+use std::pin::Pin;
 use surrealdb::sql::Value;
 
 /// A signup future
@@ -20,10 +21,10 @@ pub struct Signup<'r, C: Connection, R> {
 impl<'r, Client, R> IntoFuture for Signup<'r, Client, R>
 where
     Client: Connection,
-    R: DeserializeOwned + Send,
+    R: DeserializeOwned + Send + Sync,
 {
     type Output = Result<R>;
-    type IntoFuture = BoxFuture<'r, Result<R>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/tests/mod.rs
+++ b/src/method/tests/mod.rs
@@ -189,3 +189,21 @@ async fn api() {
     // version
     let _: Version = CLIENT.version().await.unwrap();
 }
+
+fn send_and_sync(_: impl Send + Sync) {}
+
+#[test]
+fn futures_are_send_and_sync() {
+    send_and_sync(async {
+        let client = Surreal::connect::<Test>(()).await.unwrap();
+        client.use_ns("test-ns").use_db("test-db").await.unwrap();
+        client
+            .signin(Root {
+                username: "root",
+                password: "root",
+            })
+            .await
+            .unwrap();
+        let _: Vec<User> = client.select(USER).await.unwrap();
+    });
+}

--- a/src/method/tests/protocol.rs
+++ b/src/method/tests/protocol.rs
@@ -10,11 +10,12 @@ use crate::Result;
 use crate::Route;
 use crate::Router;
 use crate::Surreal;
-use async_trait::async_trait;
 use flume::Receiver;
 use once_cell::sync::OnceCell;
 use serde::de::DeserializeOwned;
+use std::future::Future;
 use std::marker::PhantomData;
+use std::pin::Pin;
 #[cfg(feature = "ws")]
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
@@ -41,7 +42,6 @@ pub struct Client {
     method: Method,
 }
 
-#[async_trait]
 impl Connection for Client {
     type Request = (Method, Param);
     type Response = Result<DbResponse>;
@@ -50,59 +50,73 @@ impl Connection for Client {
         Self { method }
     }
 
-    async fn connect(_address: ServerAddrs, capacity: usize) -> Result<Surreal<Self>> {
-        let (route_tx, route_rx) = flume::bounded(capacity);
-        let router = Router {
-            conn: PhantomData,
-            sender: route_tx,
-            #[cfg(feature = "ws")]
-            last_id: AtomicI64::new(0),
-        };
-        server::mock(route_rx);
-        Ok(Surreal {
-            router: OnceCell::with_value(Arc::new(router)),
+    fn connect(
+        _address: ServerAddrs,
+        capacity: usize,
+    ) -> Pin<Box<dyn Future<Output = Result<Surreal<Self>>> + Send + Sync + 'static>> {
+        Box::pin(async move {
+            let (route_tx, route_rx) = flume::bounded(capacity);
+            let router = Router {
+                conn: PhantomData,
+                sender: route_tx,
+                #[cfg(feature = "ws")]
+                last_id: AtomicI64::new(0),
+            };
+            server::mock(route_rx);
+            Ok(Surreal {
+                router: OnceCell::with_value(Arc::new(router)),
+            })
         })
     }
 
-    async fn send(
-        &mut self,
-        router: &Router<Self>,
+    fn send<'r>(
+        &'r mut self,
+        router: &'r Router<Self>,
         param: Param,
-    ) -> Result<Receiver<Self::Response>> {
-        let (sender, receiver) = flume::bounded(1);
-        let route = Route {
-            request: (self.method, param),
-            response: sender,
-        };
-        router
-            .sender
-            .send_async(Some(route))
-            .await
-            .as_ref()
-            .map_err(ToString::to_string)
-            .unwrap();
-        Ok(receiver)
+    ) -> Pin<Box<dyn Future<Output = Result<Receiver<Self::Response>>> + Send + Sync + 'r>> {
+        Box::pin(async move {
+            let (sender, receiver) = flume::bounded(1);
+            let route = Route {
+                request: (self.method, param),
+                response: sender,
+            };
+            router
+                .sender
+                .send_async(Some(route))
+                .await
+                .as_ref()
+                .map_err(ToString::to_string)
+                .unwrap();
+            Ok(receiver)
+        })
     }
 
-    async fn recv<R>(&mut self, rx: Receiver<Self::Response>) -> Result<R>
+    fn recv<R>(
+        &mut self,
+        rx: Receiver<Self::Response>,
+    ) -> Pin<Box<dyn Future<Output = Result<R>> + Send + Sync + '_>>
     where
         R: DeserializeOwned,
     {
-        let result = rx.into_recv_async().await.unwrap();
-        match result.unwrap() {
-            DbResponse::Other(value) => from_value(&value),
-            DbResponse::Query(..) => unreachable!(),
-        }
+        Box::pin(async move {
+            let result = rx.into_recv_async().await.unwrap();
+            match result.unwrap() {
+                DbResponse::Other(value) => from_value(&value),
+                DbResponse::Query(..) => unreachable!(),
+            }
+        })
     }
 
-    async fn recv_query(
+    fn recv_query(
         &mut self,
         rx: Receiver<Self::Response>,
-    ) -> Result<Vec<Result<Vec<Value>>>> {
-        let result = rx.into_recv_async().await.unwrap();
-        match result.unwrap() {
-            DbResponse::Query(results) => Ok(results),
-            DbResponse::Other(..) => unreachable!(),
-        }
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Result<Vec<Value>>>>> + Send + Sync + '_>> {
+        Box::pin(async move {
+            let result = rx.into_recv_async().await.unwrap();
+            match result.unwrap() {
+                DbResponse::Query(results) => Ok(results),
+                DbResponse::Other(..) => unreachable!(),
+            }
+        })
     }
 }

--- a/src/method/unset.rs
+++ b/src/method/unset.rs
@@ -3,8 +3,9 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
+use std::pin::Pin;
 
 /// An unset future
 #[derive(Debug)]
@@ -18,7 +19,7 @@ where
     Client: Connection,
 {
     type Output = Result<()>;
-    type IntoFuture = BoxFuture<'r, Result<()>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/use_db.rs
+++ b/src/method/use_db.rs
@@ -1,9 +1,10 @@
 use crate::method::Method;
+use std::future::Future;
+use std::pin::Pin;
 use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
 use std::future::IntoFuture;
 use surrealdb::sql::Value;
 
@@ -18,7 +19,7 @@ where
     Client: Connection,
 {
     type Output = Result<()>;
-    type IntoFuture = BoxFuture<'r, Result<()>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/use_ns.rs
+++ b/src/method/use_ns.rs
@@ -3,8 +3,9 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
+use std::pin::Pin;
 
 /// Stores the namespace to use
 #[derive(Debug)]
@@ -40,7 +41,7 @@ where
     Client: Connection,
 {
     type Output = Result<()>;
-    type IntoFuture = BoxFuture<'r, Result<()>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/src/method/version.rs
+++ b/src/method/version.rs
@@ -3,8 +3,9 @@ use crate::param::Param;
 use crate::Connection;
 use crate::Result;
 use crate::Router;
-use futures::future::BoxFuture;
+use std::future::Future;
 use std::future::IntoFuture;
+use std::pin::Pin;
 
 /// A version future
 #[derive(Debug)]
@@ -17,7 +18,7 @@ where
     Client: Connection,
 {
     type Output = Result<semver::Version>;
-    type IntoFuture = BoxFuture<'r, Result<semver::Version>>;
+    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async {

--- a/src/protocol/http/wasm.rs
+++ b/src/protocol/http/wasm.rs
@@ -6,11 +6,11 @@ use crate::param::Param;
 use crate::param::ServerAddrs;
 use crate::Connection;
 use crate::Method;
+use crate::Response as QueryResponse;
 use crate::Result;
 use crate::Route;
 use crate::Router;
 use crate::Surreal;
-use async_trait::async_trait;
 use flume::Receiver;
 use flume::Sender;
 use futures::StreamExt;
@@ -21,15 +21,15 @@ use reqwest::header::HeaderValue;
 use reqwest::header::ACCEPT;
 use reqwest::ClientBuilder;
 use serde::de::DeserializeOwned;
+use std::future::Future;
 use std::marker::PhantomData;
+use std::pin::Pin;
 #[cfg(feature = "ws")]
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
-use surrealdb::sql::Value;
 use url::Url;
 use wasm_bindgen_futures::spawn_local;
 
-#[async_trait]
 impl Connection for Client {
     type Request = (Method, Param);
     type Response = Result<DbResponse>;
@@ -38,67 +38,81 @@ impl Connection for Client {
         Self { method }
     }
 
-    async fn connect(address: ServerAddrs, capacity: usize) -> Result<Surreal<Self>> {
-        let (route_tx, route_rx) = match capacity {
-            0 => flume::unbounded(),
-            capacity => flume::bounded(capacity),
-        };
+    fn connect(
+        address: ServerAddrs,
+        capacity: usize,
+    ) -> Pin<Box<dyn Future<Output = Result<Surreal<Self>>> + Send + Sync + 'static>> {
+        Box::pin(async move {
+            let (route_tx, route_rx) = match capacity {
+                0 => flume::unbounded(),
+                capacity => flume::bounded(capacity),
+            };
 
-        let (conn_tx, conn_rx) = flume::bounded(1);
+            let (conn_tx, conn_rx) = flume::bounded(1);
 
-        router(address, conn_tx, route_rx);
+            router(address, conn_tx, route_rx);
 
-        if let Err(error) = conn_rx.into_recv_async().await? {
-            return Err(error);
-        }
+            if let Err(error) = conn_rx.into_recv_async().await? {
+                return Err(error);
+            }
 
-        Ok(Surreal {
-            router: OnceCell::with_value(Arc::new(Router {
-                conn: PhantomData,
-                sender: route_tx,
-                #[cfg(feature = "ws")]
-                last_id: AtomicI64::new(0),
-            })),
+            Ok(Surreal {
+                router: OnceCell::with_value(Arc::new(Router {
+                    conn: PhantomData,
+                    sender: route_tx,
+                    #[cfg(feature = "ws")]
+                    last_id: AtomicI64::new(0),
+                })),
+            })
         })
     }
 
-    async fn send(
-        &mut self,
-        router: &Router<Self>,
+    fn send<'r>(
+        &'r mut self,
+        router: &'r Router<Self>,
         param: Param,
-    ) -> Result<Receiver<Self::Response>> {
-        let (sender, receiver) = flume::bounded(1);
-        tracing::trace!("{param:?}");
-        let route = Route {
-            request: (self.method, param),
-            response: sender,
-        };
-        router.sender.send_async(Some(route)).await?;
-        Ok(receiver)
+    ) -> Pin<Box<dyn Future<Output = Result<Receiver<Self::Response>>> + Send + Sync + 'r>> {
+        Box::pin(async move {
+            let (sender, receiver) = flume::bounded(1);
+            tracing::trace!("{param:?}");
+            let route = Route {
+                request: (self.method, param),
+                response: sender,
+            };
+            router.sender.send_async(Some(route)).await?;
+            Ok(receiver)
+        })
     }
 
-    async fn recv<R>(&mut self, rx: Receiver<Self::Response>) -> Result<R>
+    fn recv<R>(
+        &mut self,
+        rx: Receiver<Self::Response>,
+    ) -> Pin<Box<dyn Future<Output = Result<R>> + Send + Sync + '_>>
     where
         R: DeserializeOwned,
     {
-        let response = rx.into_recv_async().await?;
-        tracing::trace!("Response {response:?}");
-        match response? {
-            DbResponse::Other(value) => from_value(&value),
-            DbResponse::Query(..) => unreachable!(),
-        }
+        Box::pin(async move {
+            let response = rx.into_recv_async().await?;
+            tracing::trace!("Response {response:?}");
+            match response? {
+                DbResponse::Other(value) => from_value(&value),
+                DbResponse::Query(..) => unreachable!(),
+            }
+        })
     }
 
-    async fn recv_query(
+    fn recv_query(
         &mut self,
         rx: Receiver<Self::Response>,
-    ) -> Result<Vec<Result<Vec<Value>>>> {
-        let response = rx.into_recv_async().await?;
-        tracing::trace!("Response {response:?}");
-        match response? {
-            DbResponse::Query(results) => Ok(results),
-            DbResponse::Other(..) => unreachable!(),
-        }
+    ) -> Pin<Box<dyn Future<Output = Result<QueryResponse>> + Send + Sync + '_>> {
+        Box::pin(async move {
+            let response = rx.into_recv_async().await?;
+            tracing::trace!("Response {response:?}");
+            match response? {
+                DbResponse::Query(results) => Ok(results),
+                DbResponse::Other(..) => unreachable!(),
+            }
+        })
     }
 }
 


### PR DESCRIPTION
## What is the motivation?

Make the library easier to use with functions that require parameters to be `Sync`.

## What does this change do?

It ensures that all types used and returned by this client are both `Send` and `Sync`.

## What is your testing strategy?

I added a `futures_are_send_and_sync` test case for this.

## Is this related to any issues?

It's related to [this Discord issue](https://discord.com/channels/902568124350599239/1014970959461105664/1043516951927984168).