### PR TITLE
Create `QueryResponse` and `QueryResult` types for the `Query` method

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,17 @@
+edition = "2021"
+hard_tabs = true
+merge_derives = true
+reorder_imports = true
+reorder_modules = true
+use_field_init_shorthand = true
+use_small_heuristics = "Off"
+
+# -----------------------------------
+# Unstable options we would like to use in future
+# -----------------------------------
+
+#blank_lines_lower_bound = 1
+#indent_style = "Block"
+#match_arm_blocks = true
+#reorder_impl_items = true
+#wrap_comments = true

--- a/examples/concurrency/main.rs
+++ b/examples/concurrency/main.rs
@@ -24,13 +24,17 @@ async fn main() -> surrealdb_rs::Result<()> {
     for idx in 0..NUM {
         let sender = tx.clone();
         tokio::spawn(async move {
-            let mut result = CLIENT
+            let result = CLIENT
                 .query("SELECT * FROM $idx")
                 .bind("idx", idx)
                 .await
                 .unwrap();
-            let db_idx = result.remove(0).unwrap().remove(0);
-            tracing::info!("{idx}: {db_idx}");
+
+            let db_idx: Option<usize> = result.get(0, 0).unwrap();
+            if let Some(db_idx) = db_idx {
+                tracing::info!("{idx}: {db_idx}");
+            }
+
             drop(sender);
         });
     }

--- a/examples/query/main.rs
+++ b/examples/query/main.rs
@@ -39,7 +39,7 @@ async fn main() -> surrealdb_rs::Result<()> {
     let response = client.query("SELECT * FROM user").await?;
 
     // print all users:
-    let users: Vec<User> = response.get(0, ..)?.unwrap_or_default();
+    let users: Vec<User> = response.get(0, ..)?;
     tracing::info!("{users:?}");
 
     Ok(())

--- a/examples/query/main.rs
+++ b/examples/query/main.rs
@@ -1,5 +1,4 @@
 use serde::Deserialize;
-use surrealdb_rs::param::from_value;
 use surrealdb_rs::param::Root;
 use surrealdb_rs::protocol::Ws;
 use surrealdb_rs::Surreal;
@@ -27,15 +26,21 @@ async fn main() -> surrealdb_rs::Result<()> {
 
     client.use_ns("namespace").use_db("database").await?;
 
-    let mut results = client
+    let results = client
         .query("CREATE user SET name = $name, company = $company")
         .bind("name", "John Doe")
         .bind("company", "ACME Corporation")
         .await?;
 
-    let value = results.remove(0)?.remove(0);
-    let user: User = from_value(&value)?;
+    // print the created user:
+    let user: Option<User> = results.get(0, 0)?;
     tracing::info!("{user:?}");
+
+    let response = client.query("SELECT * FROM user").await?;
+
+    // print all users:
+    let users: Vec<User> = response.get(0, ..)?.unwrap_or_default();
+    tracing::info!("{users:?}");
 
     Ok(())
 }

--- a/examples/transaction/main.rs
+++ b/examples/transaction/main.rs
@@ -33,8 +33,7 @@ async fn main() -> surrealdb_rs::Result<()> {
         .await?;
 
     for result in results {
-        let response = result?;
-        tracing::info!("{response:?}");
+        tracing::info!("{result:?}");
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,9 +133,6 @@ use surrealdb::sql::Value;
 /// Result type returned by the client
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Response type returned by the `query` method
-pub type Response = QueryResponse;
-
 const SUPPORTED_VERSIONS: (&str, &str) = (">=1.0.0-beta.8, <2.0.0", "20221030.c12a1cc");
 
 /// Connection trait implemented by supported protocols
@@ -174,7 +171,7 @@ pub trait Connection: Sized + Send + Sync + 'static {
     fn recv_query(
         &mut self,
         receiver: Receiver<Self::Response>,
-    ) -> Pin<Box<dyn Future<Output = Result<Response>> + Send + Sync + '_>>;
+    ) -> Pin<Box<dyn Future<Output = Result<QueryResponse>> + Send + Sync + '_>>;
 
     /// Execute all methods except `query`
     fn execute<'r, R>(
@@ -196,7 +193,7 @@ pub trait Connection: Sized + Send + Sync + 'static {
         &'r mut self,
         router: &'r Router<Self>,
         param: param::Param,
-    ) -> Pin<Box<dyn Future<Output = Result<Response>> + Send + Sync + 'r>> {
+    ) -> Pin<Box<dyn Future<Output = Result<QueryResponse>> + Send + Sync + 'r>> {
         Box::pin(async move {
             let rx = self.send(router, param).await?;
             self.recv_query(rx).await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub mod protocol;
 
 pub use err::Error;
 pub use err::ErrorKind;
+use method::query_response::QueryResponse;
 
 use crate::param::ServerAddrs;
 use crate::param::ToServerAddrs;
@@ -133,7 +134,7 @@ use surrealdb::sql::Value;
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Response type returned by the `query` method
-pub type Response = Vec<Result<Vec<Value>>>;
+pub type Response = QueryResponse;
 
 const SUPPORTED_VERSIONS: (&str, &str) = (">=1.0.0-beta.8, <2.0.0", "20221030.c12a1cc");
 

--- a/src/method/mod.rs
+++ b/src/method/mod.rs
@@ -56,6 +56,7 @@ pub use kill::Kill;
 pub use live::Live;
 pub use merge::Merge;
 pub use patch::Patch;
+pub use query::response as query_response;
 pub use query::Query;
 pub use select::Select;
 pub use set::Set;

--- a/src/method/mod.rs
+++ b/src/method/mod.rs
@@ -509,7 +509,7 @@ where
     /// // Get the first result from the first query
     /// let created: Option<Person> = result.get(0, 0)?;
     /// // Get all of the results from the second query
-    /// let people: Vec<Person> = result.get(1, ..)?.unwrap_or_default();
+    /// let people: Vec<Person> = result.get(1, ..)?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/method/mod.rs
+++ b/src/method/mod.rs
@@ -507,10 +507,9 @@ where
     ///     .bind("tb", "person")
     ///     .await?;
     /// // Get the first result from the first query
-    /// let created = result.remove(0)?.remove(0);
-    /// let person: Person = from_value(&created)?;
+    /// let created: Option<Person> = result.get(0, 0)?;
     /// // Get all of the results from the second query
-    /// let people = result.remove(1)?;
+    /// let people: Vec<Person> = result.get(1, ..)?.unwrap_or_default();
     /// # Ok(())
     /// # }
     /// ```

--- a/src/method/query/mod.rs
+++ b/src/method/query/mod.rs
@@ -1,0 +1,3 @@
+mod query;
+
+pub use query::Query;

--- a/src/method/query/mod.rs
+++ b/src/method/query/mod.rs
@@ -1,3 +1,7 @@
 mod query;
 
 pub use query::Query;
+
+/// A module for the various wrapping types for the responses and results
+/// returned by the database.
+pub mod response;

--- a/src/method/query/query.rs
+++ b/src/method/query/query.rs
@@ -20,9 +20,9 @@ use surrealdb::sql::Value;
 /// A query future
 #[derive(Debug)]
 pub struct Query<'r, C: Connection> {
-    pub(super) router: Result<&'r Router<C>>,
-    pub(super) query: Vec<Result<Vec<Statement>>>,
-    pub(super) bindings: BTreeMap<String, Value>,
+    pub(in super::super) router: Result<&'r Router<C>>,
+    pub(in super::super) query: Vec<Result<Vec<Statement>>>,
+    pub(in super::super) bindings: BTreeMap<String, Value>,
 }
 
 impl<'r, Client> IntoFuture for Query<'r, Client>

--- a/src/method/query/query.rs
+++ b/src/method/query/query.rs
@@ -3,7 +3,6 @@ use crate::param;
 use crate::param::from_json;
 use crate::param::Param;
 use crate::Connection;
-use crate::Response;
 use crate::Result;
 use crate::Router;
 use serde::Serialize;
@@ -17,6 +16,8 @@ use surrealdb::sql::Statement;
 use surrealdb::sql::Statements;
 use surrealdb::sql::Value;
 
+use super::response::QueryResponse;
+
 /// A query future
 #[derive(Debug)]
 pub struct Query<'r, C: Connection> {
@@ -29,7 +30,7 @@ impl<'r, Client> IntoFuture for Query<'r, Client>
 where
     Client: Connection,
 {
-    type Output = Result<Response>;
+    type Output = Result<QueryResponse>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send + Sync + 'r>>;
 
     fn into_future(self) -> Self::IntoFuture {

--- a/src/method/query/response.rs
+++ b/src/method/query/response.rs
@@ -33,7 +33,7 @@ impl QueryResponse {
 
     /// Returns a reference the result for the `n`-th query from the response. If
     /// no result is found at this index then [None] is returned.
-    pub fn get_query(&self, n: usize) -> Option<&QueryResult> {
+    pub fn query_result(&self, n: usize) -> Option<&QueryResult> {
         self.0.get(n)
     }
 
@@ -79,7 +79,7 @@ impl QueryResponse {
         I: SliceIndex<[Value]>,
         <I as SliceIndex<[surrealdb::sql::Value]>>::Output: Serialize,
     {
-        self.get_query(query_index)
+        self.query_result(query_index)
             .and_then(|query_result| query_result.get(index_or_range).transpose())
             .transpose()
     }
@@ -173,7 +173,7 @@ impl QueryResult {
     /// # let token = String::new();
     /// let response = client.query("select * from account where balance = '$100'").await?;
     ///
-    /// if let Some(first_query_result) = response.get_query(0) {
+    /// if let Some(first_query_result) = response.query_result(0) {
     ///   // print the first account:
     ///   let account: Option<Account> = first_query_result.get(0)?;
     ///   dbg!(account);

--- a/src/method/query/response.rs
+++ b/src/method/query/response.rs
@@ -211,15 +211,20 @@ impl QueryResult {
         self.get(..)
     }
 
-    /// Returns a reference the inner [`Result`](crate::Result) with the raw
-    /// unparsed [Value]s
-    pub fn inner(&self) -> &Result<Vec<Value>> {
-        &self.0
+    /// Unwrap into the inner result and possible list of raw unparsed values
+    pub fn into_inner(self) -> Result<Vec<Value>> {
+        self.0
     }
 }
 
 impl Into<QueryResult> for Result<Vec<Value>> {
     fn into(self) -> QueryResult {
         QueryResult(self)
+    }
+}
+
+impl AsRef<Result<Vec<Value>>> for QueryResult {
+    fn as_ref(&self) -> &Result<Vec<Value>> {
+        &self.0
     }
 }

--- a/src/method/query/response.rs
+++ b/src/method/query/response.rs
@@ -41,10 +41,15 @@ impl QueryResponse {
     /// range or index for the query at `query_index`.
     ///
     /// - If no query is found at `query_index` then [`None`] is returned.
-    /// - if `index_or_range` is an index of type [usize] then a single [`Option<T>`]
+    /// - if `index_or_range` is an index of type [usize] then a single [`T`]
     /// is returned.
-    /// - if `index_or_range` is a range then a [`Option<Vec<T>>`] is returned if
+    /// - if `index_or_range` is a range then a [`Vec<T>`] is returned if
     /// and only if the full range is found inside the inner list.
+    /// 
+    /// In cases of out of bounds indices in either the query or the items then
+    /// [`T::default()`] is returned. This means that if [<T>] were to be an
+    /// Option it will return `None` and if it were to be a Vec then an empty
+    /// list will be returned.
     ///
     /// # Examples
     /// ```no_run
@@ -152,11 +157,16 @@ impl QueryResult {
     /// Returns the deserialized [`<T>`] from the inner [Value]s over the given
     /// range or index.
     ///
-    /// - if `index_or_range` is an index of type [usize] then a single [`Option<T>`]
+    /// - if `index_or_range` is an index of type [usize] then a single [`<T>`]
     /// is returned.
-    /// - if `index_or_range` is a range then a [`Option<Vec<T>>`] is returned if
+    /// - if `index_or_range` is a range then a [`Vec<T>`] is returned if
     /// and only if the full range is found inside the inner list.
     ///
+    /// In cases of out of bounds indices in either the query or the items then
+    /// [`T::default()`] is returned. This means that if [`<T>`] were to be an
+    /// Option it will return `None` and if it were to be a Vec then an empty
+    /// list will be returned.
+    /// 
     /// # Examples
     /// ```no_run
     /// # #[derive(Debug, serde::Deserialize)]

--- a/src/method/query/response.rs
+++ b/src/method/query/response.rs
@@ -24,6 +24,11 @@ impl QueryResponse {
         Self(Default::default())
     }
 
+    /// Unwrap into the inner list of query results
+    pub fn into_inner(self) -> Vec<QueryResult> {
+        self.0
+    }
+
     /// Returns a reference the result for the `n`-th query from the response. If
     /// no result is found at this index then [None] is returned.
     pub fn get_query(&self, n: usize) -> Option<&QueryResult> {

--- a/src/method/query/response.rs
+++ b/src/method/query/response.rs
@@ -6,6 +6,7 @@ use std::slice::SliceIndex;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 
+use crate::param::from_serializable;
 use crate::Result;
 use crate::Value;
 
@@ -199,15 +200,9 @@ impl QueryResult {
         <I as SliceIndex<[surrealdb::sql::Value]>>::Output: Serialize,
     {
         let values: &Vec<Value> = self.0.as_ref().map_err(|error| error.clone())?.as_ref();
-
         let some_slice = values.get::<I>(index_or_range);
         let items = match some_slice {
-            Some(slice) => {
-                let bytes = serde_pack::to_vec(slice)?;
-                let response = serde_pack::from_slice(&bytes)?;
-
-                Some(response)
-            }
+            Some(slice) => Some(from_serializable(slice)?),
             None => None,
         };
 

--- a/src/method/query/response.rs
+++ b/src/method/query/response.rs
@@ -21,7 +21,8 @@ pub struct QueryResponse(Vec<QueryResult>);
 
 impl QueryResponse {
     /// Constructs an empty [`QueryResponse`]
-    pub fn new() -> Self {
+    #[allow(unused)]
+    pub(crate) fn new() -> Self {
         Self(Default::default())
     }
 

--- a/src/method/query/response.rs
+++ b/src/method/query/response.rs
@@ -36,15 +36,6 @@ impl QueryResponse {
         self.0.get(n)
     }
 
-    /// Returns a reference to the result for the `n`-th query from the response.
-    ///
-    /// # Panics
-    /// Unlike the [`Self::get()`] function no bounding check is performed and may panic if
-    /// `n` is out of bounds.
-    pub fn get_query_unchecked(&self, n: usize) -> &QueryResult {
-        &self.0[n]
-    }
-
     /// Returns the deserialized [`<T>`] from the inner [Value]s over the given
     /// range or index for the query at `query_index`.
     ///

--- a/src/method/query/response.rs
+++ b/src/method/query/response.rs
@@ -45,7 +45,7 @@ impl QueryResponse {
     /// is returned.
     /// - if `index_or_range` is a range then a [`Vec<T>`] is returned if
     /// and only if the full range is found inside the inner list.
-    /// 
+    ///
     /// In cases of out of bounds indices in either the query or the items then
     /// [`T::default()`] is returned. This means that if [<T>] were to be an
     /// Option it will return `None` and if it were to be a Vec then an empty
@@ -86,7 +86,7 @@ impl QueryResponse {
     {
         match self.query_result(query_index) {
             None => Ok(T::default()),
-            Some(query_result) => query_result.get(index_or_range)
+            Some(query_result) => query_result.get(index_or_range),
         }
     }
 }
@@ -166,7 +166,7 @@ impl QueryResult {
     /// [`T::default()`] is returned. This means that if [`<T>`] were to be an
     /// Option it will return `None` and if it were to be a Vec then an empty
     /// list will be returned.
-    /// 
+    ///
     /// # Examples
     /// ```no_run
     /// # #[derive(Debug, serde::Deserialize)]

--- a/src/method/query/response.rs
+++ b/src/method/query/response.rs
@@ -39,11 +39,6 @@ impl QueryResponse {
         &self.0[n]
     }
 
-    /// Returns a reference to all of the results from the response.
-    pub fn all(&self) -> &Vec<QueryResult> {
-        &self.0
-    }
-
     /// Returns the deserialized [`<T>`] from the inner [Value]s over the given
     /// range or index for the query at `query_index`.
     ///
@@ -138,6 +133,12 @@ impl Index<usize> for QueryResponse {
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.0[index]
+    }
+}
+
+impl AsRef<Vec<QueryResult>> for QueryResponse {
+    fn as_ref(&self) -> &Vec<QueryResult> {
+        &self.0
     }
 }
 

--- a/src/method/query/response.rs
+++ b/src/method/query/response.rs
@@ -1,0 +1,231 @@
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::ops::Index;
+use std::slice::SliceIndex;
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::Result;
+use crate::Value;
+
+/// A wrapper type around the list of results for the queries that were returned
+/// by the database.
+///
+/// Provides utility functions to access the result of one specific query, or if
+/// needed, all queries at once.
+///
+#[derive(Debug, Clone)]
+pub struct QueryResponse(Vec<QueryResult>);
+
+impl QueryResponse {
+    /// Constructs an empty [`QueryResponse`]
+    pub fn new() -> Self {
+        Self(Default::default())
+    }
+
+    /// Returns a reference the result for the `n`-th query from the response. If
+    /// no result is found at this index then [None] is returned.
+    pub fn get_query(&self, n: usize) -> Option<&QueryResult> {
+        self.0.get(n)
+    }
+
+    /// Returns a reference to the result for the `n`-th query from the response.
+    ///
+    /// # Panics
+    /// Unlike the [`Self::get()`] function no bounding check is performed and may panic if
+    /// `n` is out of bounds.
+    pub fn get_query_unchecked(&self, n: usize) -> &QueryResult {
+        &self.0[n]
+    }
+
+    /// Returns a reference to all of the results from the response.
+    pub fn all(&self) -> &Vec<QueryResult> {
+        &self.0
+    }
+
+    /// Returns the deserialized [`<T>`] from the inner [Value]s over the given
+    /// range or index for the query at `query_index`.
+    ///
+    /// - If no query is found at `query_index` then [`None`] is returned.
+    /// - if `index_or_range` is an index of type [usize] then a single [`Option<T>`]
+    /// is returned.
+    /// - if `index_or_range` is a range then a [`Option<Vec<T>>`] is returned if
+    /// and only if the full range is found inside the inner list.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # #[derive(Debug, serde::Deserialize)]
+    /// # #[allow(dead_code)]
+    /// # struct User {
+    /// #   id: String,
+    /// #   balance: String
+    /// # }
+    /// #
+    /// # use surrealdb_rs::{Result, Surreal};
+    /// # use surrealdb_rs::net::WsClient;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<()> {
+    /// # let client = Surreal::<WsClient>::new();
+    /// # let token = String::new();
+    /// let response = client.query("select * from user").await?;
+    ///
+    /// // get the first item from the first query
+    /// let user: Option<User> = response.get(0, 0)?;
+    /// tracing::info!("{user:?}");
+    ///
+    /// // get all items from the first query
+    /// let users: Vec<User> = response.get(0, ..)?.unwrap_or_default();
+    /// tracing::info!("{users:?}");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get<T, I>(&self, query_index: usize, index_or_range: I) -> Result<Option<T>>
+    where
+        T: DeserializeOwned,
+        I: SliceIndex<[Value]>,
+        <I as SliceIndex<[surrealdb::sql::Value]>>::Output: Serialize,
+    {
+        self.get_query(query_index)
+            .and_then(|query_result| query_result.get(index_or_range).transpose())
+            .transpose()
+    }
+}
+
+impl Into<QueryResponse> for Vec<QueryResult> {
+    fn into(self) -> QueryResponse {
+        QueryResponse(self)
+    }
+}
+
+impl FromIterator<Result<Vec<Value>>> for QueryResponse {
+    fn from_iter<T: IntoIterator<Item = Result<Vec<Value>>>>(iter: T) -> Self {
+        let mut query_results = Vec::new();
+
+        for result in iter {
+            query_results.push(result.into());
+        }
+
+        query_results.into()
+    }
+}
+
+impl Deref for QueryResponse {
+    type Target = [QueryResult];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0[..]
+    }
+}
+
+impl DerefMut for QueryResponse {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0[..]
+    }
+}
+
+impl IntoIterator for QueryResponse {
+    type Item = QueryResult;
+    type IntoIter = <Vec<QueryResult> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl Index<usize> for QueryResponse {
+    type Output = QueryResult;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+/// A wrapper type around the result of a single query.
+///
+/// Provides utility functions to deserialize items (of type [Value]) into any
+/// [`<T>`] that implements [DeserializeOwned].
+#[derive(Debug, Clone)]
+pub struct QueryResult(Result<Vec<Value>>);
+
+impl QueryResult {
+    /// Returns the deserialized [`<T>`] from the inner [Value]s over the given
+    /// range or index.
+    ///
+    /// - if `index_or_range` is an index of type [usize] then a single [`Option<T>`]
+    /// is returned.
+    /// - if `index_or_range` is a range then a [`Option<Vec<T>>`] is returned if
+    /// and only if the full range is found inside the inner list.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # #[derive(Debug, serde::Deserialize)]
+    /// # #[allow(dead_code)]
+    /// # struct Account {
+    /// #   id: String,
+    /// #   balance: String
+    /// # }
+    /// #
+    /// # use surrealdb_rs::{Result, Surreal};
+    /// # use surrealdb_rs::net::WsClient;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<()> {
+    /// # let client = Surreal::<WsClient>::new();
+    /// # let token = String::new();
+    /// let response = client.query("select * from account where balance = '$100'").await?;
+    ///
+    /// if let Some(first_query_result) = response.get_query(0) {
+    ///   // print the first account:
+    ///   let account: Option<Account> = first_query_result.get(0)?;
+    ///   dbg!(account);
+    ///
+    ///   // print the first two accounts, if at least two accounts are in the response:
+    ///   let accounts: Option<Vec<Account>> = first_query_result.get(0..2)?;
+    ///   dbg!(accounts);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn get<T, I>(&self, index_or_range: I) -> Result<Option<T>>
+    where
+        T: DeserializeOwned,
+        I: SliceIndex<[Value]>,
+        <I as SliceIndex<[surrealdb::sql::Value]>>::Output: Serialize,
+    {
+        let values: &Vec<Value> = self.0.as_ref().map_err(|error| error.clone())?.as_ref();
+
+        let some_slice = values.get::<I>(index_or_range);
+        let items = match some_slice {
+            Some(slice) => {
+                let bytes = serde_pack::to_vec(slice)?;
+                let response = serde_pack::from_slice(&bytes)?;
+
+                Some(response)
+            }
+            None => None,
+        };
+
+        Ok(items)
+    }
+
+    /// Returns the deserialized [`Vec<T>`] from the inner [Value]s, if no values
+    /// are found then an empty [`Vec`] is returned instead.
+    pub fn all<T>(&self) -> Result<Vec<T>>
+    where
+        T: DeserializeOwned,
+    {
+        Ok(self.get(..)?.unwrap_or_default())
+    }
+
+    /// Returns a reference the inner [`Result`](crate::Result) with the raw
+    /// unparsed [Value]s
+    pub fn inner(&self) -> &Result<Vec<Value>> {
+        &self.0
+    }
+}
+
+impl Into<QueryResult> for Result<Vec<Value>> {
+    fn into(self) -> QueryResult {
+        QueryResult(self)
+    }
+}

--- a/src/method/tests/mod.rs
+++ b/src/method/tests/mod.rs
@@ -11,7 +11,6 @@ use crate::param::NameSpace;
 use crate::param::PatchOp;
 use crate::param::Root;
 use crate::param::Scope;
-use crate::Result;
 use crate::StaticClient;
 use crate::Surreal;
 use protocol::Client;
@@ -20,10 +19,11 @@ use semver::Version;
 use std::ops::Bound;
 use surrealdb::sql::statements::BeginStatement;
 use surrealdb::sql::statements::CommitStatement;
-use surrealdb::sql::Value;
 use types::AuthParams;
 use types::User;
 use types::USER;
+
+use super::query_response::QueryResponse;
 
 static CLIENT: Surreal<Client> = Surreal::new();
 
@@ -91,13 +91,13 @@ async fn api() {
     let _: () = CLIENT.authenticate(Jwt(String::new())).await.unwrap();
 
     // query
-    let _: Vec<Result<Vec<Value>>> = CLIENT.query("SELECT * FROM user").await.unwrap();
-    let _: Vec<Result<Vec<Value>>> = CLIENT
+    let _: QueryResponse = CLIENT.query("SELECT * FROM user").await.unwrap();
+    let _: QueryResponse = CLIENT
         .query("CREATE user:john SET name = $name")
         .bind("name", "John Doe")
         .await
         .unwrap();
-    let _: Vec<Result<Vec<Value>>> = CLIENT
+    let _: QueryResponse = CLIENT
         .query(BeginStatement)
         .query("CREATE account:one SET balance = 135605.16")
         .query("CREATE account:two SET balance = 91031.31")

--- a/src/method/tests/protocol.rs
+++ b/src/method/tests/protocol.rs
@@ -1,4 +1,5 @@
 use super::server;
+use crate::method::query_response::QueryResponse;
 use crate::param::from_value;
 use crate::param::DbResponse;
 use crate::param::Param;
@@ -19,7 +20,6 @@ use std::pin::Pin;
 #[cfg(feature = "ws")]
 use std::sync::atomic::AtomicI64;
 use std::sync::Arc;
-use surrealdb::sql::Value;
 use url::Url;
 
 #[derive(Debug)]
@@ -110,7 +110,7 @@ impl Connection for Client {
     fn recv_query(
         &mut self,
         rx: Receiver<Self::Response>,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Result<Vec<Value>>>>> + Send + Sync + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<QueryResponse>> + Send + Sync + '_>> {
         Box::pin(async move {
             let result = rx.into_recv_async().await.unwrap();
             match result.unwrap() {

--- a/src/method/tests/server.rs
+++ b/src/method/tests/server.rs
@@ -1,5 +1,6 @@
 use super::types::Credentials;
 use super::types::User;
+use crate::method::query_response::QueryResponse;
 use crate::method::Method;
 use crate::param::from_json;
 use crate::param::from_value;
@@ -67,7 +68,7 @@ pub(super) fn mock(route_rx: Receiver<Option<Route<(Method, Param), Result<DbRes
                     _ => unreachable!(),
                 },
                 Method::Query => match &params[..] {
-                    [_] | [_, _] => Ok(DbResponse::Query(Vec::new())),
+                    [_] | [_, _] => Ok(DbResponse::Query(QueryResponse::new())),
                     _ => unreachable!(),
                 },
                 Method::Create => match &params[..] {

--- a/src/param/mod.rs
+++ b/src/param/mod.rs
@@ -6,6 +6,7 @@ mod query;
 mod resource;
 mod server_addrs;
 
+use crate::method::query_response::QueryResponse;
 use crate::Result;
 use dmp::Diff;
 use serde::de::DeserializeOwned;
@@ -161,7 +162,7 @@ impl Param {
 #[derive(Debug)]
 pub enum DbResponse {
     /// The response sent for the `query` method
-    Query(crate::Response),
+    Query(QueryResponse),
     /// The response sent for any method except `query`
     Other(sql::Value),
 }

--- a/src/param/mod.rs
+++ b/src/param/mod.rs
@@ -161,7 +161,7 @@ impl Param {
 #[derive(Debug)]
 pub enum DbResponse {
     /// The response sent for the `query` method
-    Query(Vec<Result<Vec<sql::Value>>>),
+    Query(crate::Response),
     /// The response sent for any method except `query`
     Other(sql::Value),
 }

--- a/src/param/mod.rs
+++ b/src/param/mod.rs
@@ -167,14 +167,25 @@ pub enum DbResponse {
     Other(sql::Value),
 }
 
-/// Deserializes a value `T` from `SurrealDB` `Value`
+/// Internal function that accepts anything serializable, be it a value, a slice,
+/// or a string; and deserializes it into the deduced `<T>`
+pub(crate) fn from_serializable<S, T>(thing: &S) -> Result<T>
+where
+    T: DeserializeOwned,
+    S: Serialize + ?Sized,
+{
+    let bytes = serde_pack::to_vec(&thing)?;
+    let response = serde_pack::from_slice(&bytes)?;
+
+    Ok(response)
+}
+
+/// Deserializes a value `T` from `SurrealDB` [`Value`]
 pub fn from_value<T>(value: &sql::Value) -> Result<T>
 where
     T: DeserializeOwned,
 {
-    let bytes = serde_pack::to_vec(&value)?;
-    let response = serde_pack::from_slice(&bytes)?;
-    Ok(response)
+    from_serializable(value)
 }
 
 pub(crate) fn from_json(json: JsonValue) -> sql::Value {

--- a/src/protocol/http/native.rs
+++ b/src/protocol/http/native.rs
@@ -8,7 +8,7 @@ use crate::param::ServerAddrs;
 use crate::param::Tls;
 use crate::Connection;
 use crate::Method;
-use crate::Response as QueryResponse;
+use crate::QueryResponse;
 use crate::Result;
 use crate::Route;
 use crate::Router;

--- a/src/protocol/http/wasm.rs
+++ b/src/protocol/http/wasm.rs
@@ -6,7 +6,7 @@ use crate::param::Param;
 use crate::param::ServerAddrs;
 use crate::Connection;
 use crate::Method;
-use crate::Response as QueryResponse;
+use crate::QueryResponse;
 use crate::Result;
 use crate::Route;
 use crate::Router;

--- a/src/protocol/ws/native.rs
+++ b/src/protocol/ws/native.rs
@@ -1,4 +1,5 @@
 use super::PATH;
+use crate::method::query_response::QueryResponse;
 use crate::param::from_value;
 use crate::param::DbResponse;
 use crate::param::Param;
@@ -13,7 +14,6 @@ use crate::protocol::ws::PING_METHOD;
 use crate::Connection;
 use crate::ErrorKind;
 use crate::Method;
-use crate::Response as QueryResponse;
 use crate::Result;
 use crate::Route;
 use crate::Router;

--- a/src/protocol/ws/wasm.rs
+++ b/src/protocol/ws/wasm.rs
@@ -11,7 +11,7 @@ use crate::protocol::ws::PING_METHOD;
 use crate::Connection;
 use crate::ErrorKind;
 use crate::Method;
-use crate::Response as QueryResponse;
+use crate::QueryResponse;
 use crate::Result;
 use crate::Route;
 use crate::Router;


### PR DESCRIPTION
## What is the motivation?

At the moment anything returned by the `query` function is a raw `Vec<Result<Vec<Value>>>`, which isn't exactly convenient to use in most cases.

For example in real-life scenarios it is often needed to send queries to find users by their usernames to confirm if the username is available, in such a case we'd like to retrieve the first result out of the query since we expect only one element. This case forces us to write:
```rs
let response = client.query("select * from user where username = $name limit 1").await?;
let value = response.remove(0).remove(0);
let user: User = from_value(value)?;
```
The code is rather complex and is susceptible to panics.

## What does this change do?
> For reviewing purpose the changes are split into multiple commits than you can read in chronological order to progressively discover the changes.


The PR introduces two new types:
 - `QueryResponse`, formerly `Vec<Result<Vec<Value>>>`. It wraps the response for a query call, it contains the result(s) of all the queries that were sent via the `client.query()` function.
 - `QueryResult` formerly the `Result<Vec<Value>>` in `Vec<Result<Vec<Value>>>`. It wraps the result of a single query.

Once combined we get the following: `QueryResponse(Vec<QueryResult>)`.

Both of these types have utility functions as well as the basic traits for iterating or indexing the results. The example scenario above becomes:
```rs
let response = client.query("select * from user where username = $name limit 1").await?;
let user: Option<User> = response.get(0, 0)?;
```

The examples were also updated to demonstrate the other convenient features they offer such as slice indexing using ranges:
```rs
// get the 2nd, 3rd and 4th users from the first query result
let users: Vec<User> = response.get(0, 1..3)?; 
```

## What is your testing strategy?

- The examples were updated to confirm all of the existing features are still available and to demonstrate the new features as well.
- Since these two types are just wrapping types, the tests were updated to use them instead but their logic remains unchanged.
- No new tests were written for the indexing functions like the `get()` function displayed above as they all rely on the standard [`SliceIndex`](https://doc.rust-lang.org/stable/std/slice/trait.SliceIndex.html) trait for their internal logic. But of course if you feel like tests are still needed i shall write some

## Is this related to any issues?
No.

_P.S. I took the liberty to add an empty `rustfmt.toml` file so that anyone, no matter their local config, can format the code they add to the repository. If it causes any trouble i will remove it._
