### PR TITLE
Add support for binding objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ async fn main() -> Result<()> {
             FROM type::table($table)
             GROUP BY marketing
         ")
-        .bind("table", "person")
+        .bind(("table", "person"))
         .await?;
 
     dbg!(groups);

--- a/examples/concurrency/main.rs
+++ b/examples/concurrency/main.rs
@@ -21,7 +21,7 @@ async fn main() -> surrealdb_rs::Result<()> {
 	for idx in 0..NUM {
 		let sender = tx.clone();
 		tokio::spawn(async move {
-			let result = CLIENT.query("SELECT * FROM $idx").bind("idx", idx).await.unwrap();
+			let result = CLIENT.query("SELECT * FROM $idx").bind(("idx", idx)).await.unwrap();
 
 			let db_idx: Option<usize> = result.get(0, 0).unwrap();
 			if let Some(db_idx) = db_idx {

--- a/examples/query/main.rs
+++ b/examples/query/main.rs
@@ -1,9 +1,10 @@
 use serde::Deserialize;
+use serde::Serialize;
 use surrealdb_rs::param::Root;
 use surrealdb_rs::protocol::Ws;
 use surrealdb_rs::Surreal;
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[allow(dead_code)]
 struct User {
 	id: String,
@@ -28,8 +29,11 @@ async fn main() -> surrealdb_rs::Result<()> {
 
 	let results = client
 		.query("CREATE user SET name = $name, company = $company")
-		.bind("name", "John Doe")
-		.bind("company", "ACME Corporation")
+		.bind(User {
+			id: "john".to_owned(),
+			name: "John Doe".to_owned(),
+			company: "ACME Corporation".to_owned(),
+		})
 		.await?;
 
 	// print the created user:

--- a/src/err.rs
+++ b/src/err.rs
@@ -23,6 +23,8 @@ pub enum ErrorKind {
 	Socket,
 	/// Syntax unsupported
 	SyntaxUnsupported,
+	/// Invalid query bindings
+	InvalidBindings,
 	/// Invalid request
 	InvalidRequest,
 	/// Invalid params
@@ -54,6 +56,7 @@ impl ErrorKind {
 			ErrorKind::RangeUnsupported => format!("range not supported for {context}"),
 			ErrorKind::Socket => format!("socket error; {context}"),
 			ErrorKind::SyntaxUnsupported => format!("{context} syntax is not supported"),
+			ErrorKind::InvalidBindings => format!("invalid query bindings; {context}"),
 			_ => context.to_string(),
 		};
 		Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@
 //!     // Perform a custom advanced query
 //!     let groups = client
 //!         .query("SELECT marketing, count() FROM type::table($tb) GROUP BY marketing")
-//!         .bind("tb", "person")
+//!         .bind(("tb", "person"))
 //!         .await?;
 //!
 //!     Ok(())

--- a/src/method/mod.rs
+++ b/src/method/mod.rs
@@ -506,7 +506,7 @@ where
 	/// let mut result = client
 	///     .query("CREATE person")
 	///     .query("SELECT * FROM type::table($tb)")
-	///     .bind("tb", "person")
+	///     .bind(("tb", "person"))
 	///     .await?;
 	/// // Get the first result from the first query
 	/// let created: Option<Person> = result.get(0, 0)?;
@@ -519,7 +519,7 @@ where
 		Query {
 			router: self.router.extract(),
 			query: vec![query.try_into_query()],
-			bindings: Default::default(),
+			bindings: Ok(Default::default()),
 		}
 	}
 

--- a/src/method/tests/mod.rs
+++ b/src/method/tests/mod.rs
@@ -93,7 +93,15 @@ async fn api() {
 	// query
 	let _: QueryResponse = CLIENT.query("SELECT * FROM user").await.unwrap();
 	let _: QueryResponse =
-		CLIENT.query("CREATE user:john SET name = $name").bind("name", "John Doe").await.unwrap();
+		CLIENT.query("CREATE user:john SET name = $name").bind(("name", "John Doe")).await.unwrap();
+	let _: QueryResponse = CLIENT
+		.query("CREATE user:john SET name = $name")
+		.bind(User {
+			id: "john".to_owned(),
+			name: "John Doe".to_owned(),
+		})
+		.await
+		.unwrap();
 	let _: QueryResponse = CLIENT
 		.query(BeginStatement)
 		.query("CREATE account:one SET balance = 135605.16")

--- a/tests/native-http.rs
+++ b/tests/native-http.rs
@@ -250,8 +250,15 @@ async fn query_binds() {
 	client.use_ns(NS).use_db(DB).await.unwrap();
 	client
 		.query("CREATE type::thing($table, john) SET name = $name")
-		.bind("table", user)
-		.bind("name", "John Doe")
+		.bind(("table", user))
+		.bind(("name", "John Doe"))
+		.await
+		.unwrap();
+	client
+		.query("CREATE user SET name = $name")
+		.bind(Record {
+			name: "John Doe",
+		})
 		.await
 		.unwrap();
 }
@@ -268,7 +275,7 @@ async fn query_chaining() {
 		.query("UPDATE type::thing($table, one) SET balance += 300.00")
 		.query("UPDATE type::thing($table, two) SET balance -= 300.00")
 		.query(CommitStatement)
-		.bind("table", account)
+		.bind(("table", account))
 		.await
 		.unwrap();
 }

--- a/tests/native-ws.rs
+++ b/tests/native-ws.rs
@@ -249,8 +249,15 @@ async fn query_binds() {
 	client.use_ns(NS).use_db(DB).await.unwrap();
 	client
 		.query("CREATE type::thing($table, john) SET name = $name")
-		.bind("table", user)
-		.bind("name", "John Doe")
+		.bind(("table", user))
+		.bind(("name", "John Doe"))
+		.await
+		.unwrap();
+	client
+		.query("CREATE user SET name = $name")
+		.bind(Record {
+			name: "John Doe",
+		})
 		.await
 		.unwrap();
 }
@@ -267,7 +274,7 @@ async fn query_chaining() {
 		.query("UPDATE type::thing($table, one) SET balance += 300.00")
 		.query("UPDATE type::thing($table, two) SET balance -= 300.00")
 		.query(CommitStatement)
-		.bind("table", account)
+		.bind(("table", account))
 		.await
 		.unwrap();
 }


### PR DESCRIPTION
## What is the motivation?

Currently `query.bind(..)` only supports binding explicit key/value pairs, for example `query.bind("name", "John Doe")`.
In some cases, it may be more convenient to bind an object instead.

## What does this change do?

It extends `bind` to take any serializable object including tuples. This allows one to pass in a key/value pair using a tuple

```rust
query.bind(("name", "John Doe")).await?;
```

or an object

```rust
// a dynamic object
query.bind(json!({ "name": "John Doe" })).await?;

// or a struct
query.bind(User {
    name: "John Doe",
}).await?;
```

## What is your testing strategy?

Updated the tests to cover both tuples and objects.

## Is this related to any issues?

It addresses https://discord.com/channels/902568124350599239/1014970959461105664/1047484388939665468.