### PR TITLE
Add `QueryResponse::get_key` function

### DIFF
--- a/tests/types.rs
+++ b/tests/types.rs
@@ -2,6 +2,10 @@
 
 use serde::Deserialize;
 use serde::Serialize;
+use surrealdb::sql::Uuid;
+use surrealdb_rs::param::Root;
+use surrealdb_rs::param::ToServerAddrs;
+use surrealdb_rs::Surreal;
 
 pub const NS: &str = "test-ns";
 pub const DB: &str = "test-db";
@@ -23,4 +27,28 @@ pub struct RecordId {
 pub struct AuthParams<'a> {
 	pub email: &'a str,
 	pub pass: &'a str,
+}
+
+/// Returns a sort of "sandboxed" client in the way it uses a completely random
+/// namespace/database pair to ensure the data that is pushed & retrieved from/to
+/// that client is strictly unique to it and won't interfere with other tests.
+pub async fn sandboxed_client<'a, Protocol>(
+) -> Surreal<<&'a str as ToServerAddrs<Protocol>>::Client>
+where
+	&'a str: ToServerAddrs<Protocol>,
+{
+	let client = Surreal::connect::<Protocol>(DB_ENDPOINT).await.unwrap();
+	client
+		.signin(Root {
+			username: ROOT_USER,
+			password: ROOT_PASS,
+		})
+		.await
+		.unwrap();
+
+	// use
+	let _: () =
+		client.use_ns(Uuid::new().to_string()).use_db(Uuid::new().to_string()).await.unwrap();
+
+	client
 }


### PR DESCRIPTION
## What is the motivation?
The current implementation of the `QueryResponse` type lacks the functions to retrieve a specific key from the selected rows without de-serializing the whole objects (which may represent a serious performance cost) or accessing the inner values manually (which isn't convenient)

**Example scenario 1**. We would like to get some user IDs:
```rs
let response = client.query("select id from User").await?;
let ids: Vec<String> = response.get(0, ..)?;
```
but this will result in an error: `value: Error { kind: Deserialization, message: "invalid type: map, expected a string" }`

**Example scenario 2**.  We would like to get nodes from an edge:
```rs
let response = client.query("select ->write->Article as written_articles from User").await?;
let articles: Vec<Article> = response.get(0, 0)?;
```
but this will result in an error similar to the scenario 1.

## What does this change do?
This PR adds the `response.get_key(0, "id", ..)?` method so one can retrieve one specific field from the selected rows.
```rs
let response = client.query("select ->write->Article as written_articles from User").await?;
let articles: Vec<Article> = response.get_key(0, "written_articles", 0)?;
```

I have decided to put the `key` parameter in second before the range in `get_key(query, key, range)` to represent the "_get me the first query and its field `key` from the given `range`_" formula like "_select key from range_". This can be changed obviously if you don't like it!

## What is your testing strategy?
[Unit tests were added](https://github.com/surrealdb/surrealdb.rs/pull/15/commits/4f691e67035f30caf41d2245478023bfa79e0607) to confirm the behaviour of the `get_key` function. This was done by first testing the original `get` function, and then adding two more tests for the `get_key` function itself.

_Note: I did not know where to place the tests so at the moment only the native-ws part has them. I also needed specific data for the tests but i feared breaking previous tests by inserting them, i then added a `sandboxed_client` function that returns a client with a unique ns/db pair so i'm sure that data is only accessible by these tests._

## Is this related to any issues?
_No._
